### PR TITLE
Unmark targets if on the target tool

### DIFF
--- a/deselection/deselection/deselection.js
+++ b/deselection/deselection/deselection.js
@@ -14,11 +14,9 @@ class Deselection {
 			13,
 			"if ( isSelect ) return;",
 			`
-			if ( isSelect && canvas.controls.select.active ) {
-				canvas.controls.select.clear();
-				canvas.controls.select.active = false;
-				if ( tool === "select" ) return layer.selectObjects(coords);
-				if ( tool === "target" ) return layer.targetObjects(coords, {releaseOthers: !originalEvent.shiftKey});
+			if ( isSelect && tool === "target" ) {
+				canvas.activeLayer.targetObjects({}, {releaseOthers: true});
+				return;
 			};
 			`
 		);


### PR DESCRIPTION
This should fix Deselection so that it works for targets as well, but doesn't deselect your selections.