### PR TITLE
Added Spell DC below Armor Class

### DIFF
--- a/alt5e/alt5e/templates/alt5e-sheet.html
+++ b/alt5e/alt5e/templates/alt5e-sheet.html
@@ -43,6 +43,10 @@
 						<input class="ac-display" name="data.attributes.ac.value" type="text" value="{{data.attributes.ac.value}}"
 							data-dtype="Number" placeholder="10"/>
 					</div>
+					{{!-- SPELL DC --}}
+					<footer class="attribute-footer">
+						<span class="spell-dc">{{localize "DND5E.SpellDC"}} {{data.attributes.spelldc}}</span>
+					</footer>
 				</li>
 				
 				{{!-- HIT POINTS --}}


### PR DESCRIPTION
Added Spell DC below Armor Class on the main tab ("Core" tab) of the Character Sheet. Spell DC is a common stat that is referred to by spellcasters, so it's great to have it in the "Core" tab somewhere intuitive.

Diff'ed part was directly taken from the official D&D 5e compendium Gitlab repo from their characer_sheet.html file (Lines  83-85): https://gitlab.com/foundrynet/dnd5e/-/blob/master/templates/actors/character-sheet.html